### PR TITLE
Hamburger menu updated

### DIFF
--- a/src/components/header/NavBar.css
+++ b/src/components/header/NavBar.css
@@ -69,7 +69,7 @@
 }
 .navBar_link-item::before {
   top: 0;
-  height: 2px;
+  height: 2.5px;
   transform-origin: left;
 }
 .navBar_link-item:hover::after,
@@ -122,7 +122,7 @@
     width: 50vw;
     position: absolute;
     text-align: center;
-    height: 90vh;
+    height: 100vh;
     margin-top: 0;
     padding-top: 1vh;
     padding-right: 0;
@@ -147,7 +147,7 @@
     font-size: 150%;
   }
   .navBar_link-item:hover a {
-    color: rgb(104, 0, 104);
+    color: white;
   }
   .navBar_link-item::after,
   .navBar_link-item::before {


### PR DESCRIPTION
1) Nav menu in mobile view is 100vh now. 2) Now, In mobile view, if you have not scrolled down and u have opened the hamburger menu, then on hover, nav link color will be white. 3) Now, On hover, the line that appears above the link has equal height to the line below it. Issue #68 solved